### PR TITLE
updated libqasm submodule url to avoid failing CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src/parser/libqasm"]
 	path = src/parser/libqasm
-	url = git@github.com:QE-Lab/libqasm.git
+	url = https://github.com/QE-Lab/libqasm.git
 	branch = develop


### PR DESCRIPTION
libqasm submodule url has been changed to https://github.com/QE-Lab/qx-simulator.git to avoid failing CI