### PR TITLE
"Fix" pthread_setaffinity errors

### DIFF
--- a/src/xpu-0.1.5/xpu/core/generic_worker.h
+++ b/src/xpu-0.1.5/xpu/core/generic_worker.h
@@ -148,11 +148,14 @@ namespace xpu
 		     if (pthread_create(&m_id, &m_attr, reinterpret_cast<__xpu_task>(&run), (void*)this) != 0) 
 			throw (xpu::exception("thread::start() : pthread_create() failed ",true)); 
 		     // set cpu
+		     /* NOTE (Jeroen van Straten): this stuff causes crashes, undoubtedly
+		     because m_cpu contains garbage when set_cpu() is never called.
 		     cpu_set_t cpuset;
 		     CPU_ZERO(&cpuset);
 		     CPU_SET(m_cpu, &cpuset);
 		     if (pthread_setaffinity_np(m_id, sizeof(cpu_set_t), &cpuset))
 			throw (xpu::exception("thread::start() : pthread_setaffinity_np() failed ",true));
+		     */
 		     #endif
 		  }
 


### PR DESCRIPTION
This works around the occasional `thread::start() : pthread_setaffinity_np() failed` exception that's been plaguing the Quantum Inspire team. The exception most likely occurs because `m_cpu` is only initialized when `set_cpu()` is first called and thus might contain garbage for some code paths, or perhaps because `set_cpu()` is called with garbage. I just tore out the entire processor affinity call; it really shouldn't functionally matter what processor a thread runs on, and in terms of performance I doubt this would actually have helped, considering the state of the codebase.