### PR TITLE
Optimised OMP parallel regions, minor improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,17 +14,30 @@ ELSE(OPENMP_FOUND)
   message("ERROR: OpenMP could not be found.")
 ENDIF(OPENMP_FOUND)
 
-IF(CMAKE_COMPILER_IS_GNUCXX)
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wfatal-errors -O3 -DCG_BC -DQX_SPARSE_MV_MUL -D__BUILTIN_LINALG__ -Wno-sign-compare -msse4.2 -DUSE_OPENMP -Wno-unused-variable -Wno-reorder")
-ENDIF(CMAKE_COMPILER_IS_GNUCXX)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+IF("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
+  add_compile_options(-O3 -msse4.2 -Wall -Wfatal-errors -DCG_BC -DQX_SPARSE_MV_MUL -D__BUILTIN_LINALG__ -Wno-sign-compare -DUSE_OPENMP -Wno-unused-variable -Wno-reorder)
+  if(USE_GPERFTOOLS)
+    add_compile_options(-g3)
+  endif()
+ENDIF("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
+
+IF("${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel")
+  add_compile_options(-O3 -ipo -xHost -no-prec-div -Wall -Wfatal-errors -DCG_BC -DQX_SPARSE_MV_MUL -D__BUILTIN_LINALG__ -DUSE_OPENMP -Wno-reorder -Wno-unused-variable -Wno-unused-function)
+  if(USE_GPERFTOOLS)
+    add_compile_options(-g -debug all -O3 -traceback)
+  endif()
+ENDIF("${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel")
 
 IF("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   SET(CXX "Clang-omp++")
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -std=c++11 -Wall -Wfatal-errors -Wno-unused-local-typedef -O3 -DCG_BC -DQX_SPARSE_MV_MUL -D__BUILTIN_LINALG__ -msse4.2 -DUSE_OPENMP -Wno-reorder -Wno-unneeded-internal-declaration -Wno-unused-variable -Wno-unused-private-field -Wno-deprecated-register -Wno-unused-function")
+  add_compile_options(-O3 -Wall -Wfatal-errors -Wno-unused-local-typedef -O3 -DCG_BC -DQX_SPARSE_MV_MUL -D__BUILTIN_LINALG__ -msse4.2 -DUSE_OPENMP -Wno-reorder -Wno-unneeded-internal-declaration -Wno-unused-variable -Wno-unused-private-field -Wno-deprecated-register -Wno-unused-function)
 ENDIF("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DXPU_TIMER")
+add_compile_options(-DXPU_TIMER)
 
 ADD_SUBDIRECTORY(
   src bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,18 +14,15 @@ ELSE(OPENMP_FOUND)
   message("ERROR: OpenMP could not be found.")
 ENDIF(OPENMP_FOUND)
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
-
 IF("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-  add_compile_options(-O3 -msse4.2 -Wall -Wfatal-errors -DCG_BC -DQX_SPARSE_MV_MUL -D__BUILTIN_LINALG__ -DUSE_OPENMP -Wno-sign-compare -Wno-unused-variable -Wno-reorder)
+  add_compile_options(-O3 -msse4.2 -std=c++11 -Wall -Wfatal-errors -DCG_BC -DQX_SPARSE_MV_MUL -D__BUILTIN_LINALG__ -DUSE_OPENMP -Wno-sign-compare -Wno-unused-variable -Wno-reorder)
   if(USE_GPERFTOOLS)
     add_compile_options(-g3)
   endif()
 ENDIF("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 
 IF("${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel")
-  add_compile_options(-O3 -ipo -xHost -no-prec-div -Wall -Wfatal-errors -DCG_BC -DQX_SPARSE_MV_MUL -D__BUILTIN_LINALG__ -DUSE_OPENMP -Wno-reorder -Wno-unused-variable -Wno-unused-function)
+  add_compile_options(-O3 -ipo -xHost -std=c++11 -no-prec-div -Wall -Wfatal-errors -DCG_BC -DQX_SPARSE_MV_MUL -D__BUILTIN_LINALG__ -DUSE_OPENMP -Wno-reorder -Wno-unused-variable -Wno-unused-function)
   if(USE_GPERFTOOLS)
     add_compile_options(-g -debug all -O3 -traceback)
   endif()
@@ -33,7 +30,7 @@ ENDIF("${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel")
 
 IF("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   SET(CXX "Clang-omp++")
-  add_compile_options(-O3 -Wall -Wfatal-errors -Wno-unused-local-typedef -O3 -DCG_BC -DQX_SPARSE_MV_MUL -D__BUILTIN_LINALG__ -msse4.2 -DUSE_OPENMP -Wno-reorder -Wno-unneeded-internal-declaration -Wno-unused-variable -Wno-unused-private-field -Wno-deprecated-register -Wno-unused-function)
+  add_compile_options(-O3 -std=c++11 -Wall -Wfatal-errors -Wno-unused-local-typedef -O3 -DCG_BC -DQX_SPARSE_MV_MUL -D__BUILTIN_LINALG__ -msse4.2 -DUSE_OPENMP -Wno-reorder -Wno-unneeded-internal-declaration -Wno-unused-variable -Wno-unused-private-field -Wno-deprecated-register -Wno-unused-function)
 ENDIF("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 IF("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-  add_compile_options(-O3 -msse4.2 -Wall -Wfatal-errors -DCG_BC -DQX_SPARSE_MV_MUL -D__BUILTIN_LINALG__ -Wno-sign-compare -DUSE_OPENMP -Wno-unused-variable -Wno-reorder)
+  add_compile_options(-O3 -msse4.2 -Wall -Wfatal-errors -DCG_BC -DQX_SPARSE_MV_MUL -D__BUILTIN_LINALG__ -DUSE_OPENMP -Wno-sign-compare -Wno-unused-variable -Wno-reorder)
   if(USE_GPERFTOOLS)
     add_compile_options(-g3)
   endif()

--- a/qxelarator/qxelarator/qx_simulator.h
+++ b/qxelarator/qxelarator/qx_simulator.h
@@ -9,9 +9,6 @@
 #ifndef QX_SIMULATOR_H
 #define QX_SIMULATOR_H
 
-#include <xpu.h>
-#include <xpu/runtime>
-
 #include <core/circuit.h>
 #include <qx_representation.h>
 #include <libqasm_interface.h>
@@ -48,8 +45,8 @@ protected:
     compiler::QasmRepresentation ast;
 
 public:
-    simulator() : reg(nullptr) { xpu::init(); }
-    ~simulator() { xpu::clean(); }
+    simulator() : reg(nullptr) { /*xpu::init();*/ }
+    ~simulator() { /*xpu::clean();*/ }
 
     void set(std::string file_path)
     {
@@ -99,12 +96,12 @@ public:
         catch(std::bad_alloc& exception)
         {
             std::cerr << "Not enough memory, aborting" << std::endl;
-            xpu::clean();
+            // xpu::clean();
         }
         catch(std::exception& exception)
         {
             std::cerr << "Unexpected exception (" << exception.what() << "), aborting" << std::endl;
-            xpu::clean();
+            // xpu::clean();
         }
 
         // convert libqasm ast to qx internal representation
@@ -118,7 +115,7 @@ public:
             catch (std::string type)
             {
                 std::cerr << "Encountered unsupported gate: " << type << std::endl;
-                xpu::clean();
+                // xpu::clean();
             }
         }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,4 +13,11 @@ ADD_EXECUTABLE(qx-server qx_server.cc)
 ADD_EXECUTABLE(qx-simulator-old simulator_old.cc)
 ADD_EXECUTABLE(qx-simulator simulator.cc)
 
+if(USE_GPERFTOOLS)
+  target_link_libraries(qx-simulator profiler)
+  message("-- Compiling with gperftools: yes")
+else()
+  message("-- Compiling with gperftools: no")
+endif()
+
 TARGET_LINK_LIBRARIES(qx-simulator lexgram)

--- a/src/core/register.cc
+++ b/src/core/register.cc
@@ -85,7 +85,9 @@ qx::qu_register::qu_register(uint64_t n_qubits) : data(1ULL << n_qubits), aux(1U
    }
 
    data[0] = complex_t(1,0);
-   for (uint64_t i=1; i<(1ULL << n_qubits); ++i) {
+   uint64_t num_elts = (1ULL << n_qubits);
+#pragma omp parallel for
+   for (uint64_t i=1; i<num_elts; ++i) {
       data[i] = 0;
    }
 
@@ -163,7 +165,7 @@ uint64_t qx::qu_register::states()
 /**
  * \brief assign operator
  */
-cvector_t & qx::qu_register::operator=(cvector_t d) 
+cvector_t & qx::qu_register::operator=(cvector_t d)
 { 
    assert(d.size() == data.size());
    data.resize(d.size());

--- a/src/simulator.cc
+++ b/src/simulator.cc
@@ -9,7 +9,9 @@
 #include <qx_representation.h>
 #include <libqasm_interface.h>
 #include <qasm_semantic.hpp>
-
+#ifdef USE_GPERFTOOLS
+#include <gperftools/profiler.h>
+#endif
 
 #include <iostream>
 
@@ -134,6 +136,9 @@ int main(int argc, char **argv)
    // measurement averaging
    if (navg)
    {
+#ifdef USE_GPERFTOOLS
+      ProfilerStart("profile.log");
+#endif
       if (error_model == qx::__depolarizing_channel__)
       {
          qx::measure m;
@@ -168,7 +173,9 @@ int main(int argc, char **argv)
             m.apply(*reg);
          }
       }
-      
+#ifdef USE_GPERFTOOLS
+      ProfilerStop();
+#endif
       println("[+] average measurement after " << navg << " shots:");
       reg->dump(true);
    }

--- a/src/xpu-0.1.5/xpu/complex.h
+++ b/src/xpu-0.1.5/xpu/complex.h
@@ -376,18 +376,7 @@ namespace xpu
 	
 	 inline double norm()
 	 {
-		// __m128d c = _mm_mul_pd(xmm,xmm);
-		// return _mm_cvtsd_f64(_mm_hadd_pd(c,c));
-
 		return _mm_cvtsd_f64(_mm_hadd_pd(_mm_mul_pd(xmm,xmm),_mm_set1_pd(0.)));
-
-	    // __m128d c = xmm; 
-	    // c = _mm_mul_pd(c,c);
-	    // c = _mm_hadd_pd(c,c);
-		// return _mm_cvtsd_f64(c);
-	    // __v2d x; 
-	    // x.xmm = c;
-	    // return x.d1;
 	 }
 
 	 friend std::ostream &operator<<(std::ostream &os, const complex_d& c)

--- a/src/xpu-0.1.5/xpu/complex.h
+++ b/src/xpu-0.1.5/xpu/complex.h
@@ -151,7 +151,7 @@ namespace xpu
 #endif
 	 }
 
-	 void operator = (const complex_d& v)
+	 inline void operator = (const complex_d& v)
 	 {
 #ifdef __SSE__
 	    xmm = v.xmm;
@@ -162,7 +162,7 @@ namespace xpu
 	 }
 
 
-	 void operator = (const double *v)
+	 inline void operator = (const double *v)
 	 {
 #ifdef __SSE__
 	    xmm = _mm_loadu_pd(v);
@@ -172,33 +172,33 @@ namespace xpu
 #endif
 	 }
 
-	 void operator = (const double v)
+	 inline void operator = (const double v)
 	 {
 #ifdef __SSE__
 	    // xmm = _mm_set1_pd(v);
 	    this->re = v;
-	    this->im = 0; //(double)v;
+	    this->im = 0.; //(double)v;
 #else
 	    this->re = v;
-	    this->im = 0; //(double)v;
+	    this->im = 0.; //(double)v;
 #endif
 	 }
 
 
-	 void operator = (const int v)
+	 inline void operator = (const int v)
 	 {
 #ifdef __SSE__
 	    // xmm = _mm_set1_pd((double)v);
 	    this->re = (double)v;
-	    this->im = 0; //(double)v;
+	    this->im = 0.; //(double)v;
 #else
 	    this->re = (double)v;
-	    this->im = 0; //(double)v;
+	    this->im = 0.; //(double)v;
 #endif
 	 }
 
 
-	 complex_d operator* (const complex_d &v) const
+	 inline complex_d operator* (const complex_d &v) const
 	 { 
 	    #ifdef __SSE__
 	    /*
@@ -249,7 +249,7 @@ namespace xpu
 	    #endif
 	 }
 
-	 complex_d operator+ (const complex_d &v) const
+	 inline complex_d operator+ (const complex_d &v) const
 	 { 
 #ifdef __SSE__
 	    return complex_d(_mm_add_pd(xmm, v.xmm)); 
@@ -258,7 +258,7 @@ namespace xpu
 #endif
 	 }
 
-	 complex_d operator- (const complex_d &v) const
+	 inline complex_d operator- (const complex_d &v) const
 	 { 
 #ifdef __SSE__
 	    return complex_d(_mm_sub_pd(xmm, v.xmm)); 
@@ -267,7 +267,7 @@ namespace xpu
 #endif
 	 }
 
-	 complex_d operator/ (const double &v) const
+	 inline complex_d operator/ (const double &v) const
 	 { 
 	    #ifdef __SSE__
 	    __m128d d = _mm_set1_pd(v);
@@ -277,7 +277,7 @@ namespace xpu
 	    #endif
 	 }
 
-	 void operator*= (const complex_d &v)
+	 inline void operator*= (const complex_d &v)
 	 { 
 	    #ifdef __SSE__DISABLE
 	    /*
@@ -320,7 +320,7 @@ namespace xpu
 	    #endif
 	 }
 
-	 void operator+= (const complex_d &v)
+	 inline void operator+= (const complex_d &v)
 	 { 
 	    #ifdef __SSE__
 	    xmm = _mm_add_pd(xmm, v.xmm); 
@@ -330,7 +330,7 @@ namespace xpu
 	    #endif
 	 }
 
-	 void operator-= (const complex_d &v)
+	 inline void operator-= (const complex_d &v)
 	 { 
 	    #ifdef __SSE__
 	    xmm = _mm_sub_pd(xmm, v.xmm); 
@@ -340,7 +340,7 @@ namespace xpu
 	    #endif
 	 }
 
-	 void operator/= (const double &v)
+	 inline void operator/= (const double &v)
 	 { 	    
 	    #ifdef __SSE__
 	    __m128d d = _mm_set1_pd(v);
@@ -351,7 +351,7 @@ namespace xpu
 	    #endif
 	 }
 
-	 void operator/= (const complex_d &v)
+	 inline void operator/= (const complex_d &v)
 	 { 	    
 	    // #ifdef __SSE__
 	    // __m128d d = _mm_set1_pd(v);
@@ -374,14 +374,20 @@ namespace xpu
 	    #endif
 	 }
 	
-	 double norm()
+	 inline double norm()
 	 {
-	    __m128d c = xmm; 
-	    c = _mm_mul_pd(c,c);
-	    c = _mm_hadd_pd(c,c);
-	    __v2d x; 
-	    x.xmm = c;
-	    return x.d1;
+		// __m128d c = _mm_mul_pd(xmm,xmm);
+		// return _mm_cvtsd_f64(_mm_hadd_pd(c,c));
+
+		return _mm_cvtsd_f64(_mm_hadd_pd(_mm_mul_pd(xmm,xmm),_mm_set1_pd(0.)));
+
+	    // __m128d c = xmm; 
+	    // c = _mm_mul_pd(c,c);
+	    // c = _mm_hadd_pd(c,c);
+		// return _mm_cvtsd_f64(c);
+	    // __v2d x; 
+	    // x.xmm = c;
+	    // return x.d1;
 	 }
 
 	 friend std::ostream &operator<<(std::ostream &os, const complex_d& c)


### PR DESCRIPTION
Hi there, 
I'm working with `qx-simulator` at SURF and got some additions/improvements to the `without-xpu` branch. Those are related to:
- better parallelization of the OMP parallel regions
- basic improvement of the memory allocation following the "first-touch" policy
- additional AVX512 support for `renorm_worker()` function
- minor improvement over the branch prediction in `zero_worker()` function
- minor improvement of the `xpu::complex_d::norm()` method
- enhancement of the `CMakeLists` to work with Intel compilers and `gperftools`

Please, take a look and let me know if you find them useful.