### PR TITLE
Build using at most SSE3 instructions on CI

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -32,6 +32,8 @@ jobs:
         echo "/usr/local/opt/bison/bin" >> $GITHUB_PATH
         echo "/usr/local/opt/flex/bin" >> $GITHUB_PATH
         python -m pip install --upgrade pip setuptools wheel
+    - name: Enable CPU compatibility mode
+      run: echo "QX_CPU_COMPATIBILITY_MODE=ON" >> $GITHUB_ENV
     - name: Build wheel
       env:
         NPROCS: 5
@@ -90,6 +92,8 @@ jobs:
         make install
     - name: Install cmake
       run: curl -L https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz | tar xz --strip-components=1 -C /usr
+    - name: Enable CPU compatibility mode
+      run: echo "QX_CPU_COMPATIBILITY_MODE=ON" >> $GITHUB_ENV
     - name: Build wheel
       env:
         NPROCS: 5
@@ -143,6 +147,8 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         choco install winflexbison3 --version 2.5.18.20190508
         choco install swig --version 4.0.1
+    - name: Enable CPU compatibility mode
+      run: echo "QX_CPU_COMPATIBILITY_MODE=ON" >> $GITHUB_ENV
     - name: Build wheel
       env:
         NPROCS: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,10 +95,14 @@ jobs:
     - name: Select build type
       if: matrix.os == 'windows-latest'
       shell: powershell
-      run: echo "QX_BUILD_TYPE=Release" >> $GITHUB_ENV
+      run: |
+        echo "QX_BUILD_TYPE=Release" >> $GITHUB_ENV
+        echo "QX_CPU_COMPATIBILITY_MODE=ON" >> $GITHUB_ENV
     - name: Select build type
       if: matrix.os != 'windows-latest'
-      run: echo "QX_BUILD_TYPE=Debug" >> $GITHUB_ENV
+      run: |
+        echo "QX_BUILD_TYPE=Debug" >> $GITHUB_ENV
+        echo "QX_CPU_COMPATIBILITY_MODE=ON" >> $GITHUB_ENV
     - name: Build
       env:
         NPROCS: 5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,14 @@ if(NOT CMAKE_BUILD_TYPE)
     )
 endif()
 
+# Compatibility mode for building binaries that should work on basically any
+# CPU, rather than trying to optimize for the host architecture.
+option(
+    QX_CPU_COMPATIBILITY_MODE
+    "Don't assume availability of instruction set extensions beyond SSE3."
+    OFF
+)
+
 # Whether tests should be built.
 option(
     QX_BUILD_TESTS
@@ -157,16 +165,35 @@ if(NOT MSVC AND "${CMAKE_BUILD_TYPE}" STREQUAL "Release")
 endif()
 
 # Compiler-specific and architectural optimizations.
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-    target_compile_options(qx PUBLIC -march=native)
-elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel")
-    target_compile_options(qx PUBLIC -ipo -xHost -no-prec-div)
-elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-    target_compile_options(qx PUBLIC -msse4.2)
-elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
-    target_compile_options(qx PUBLIC /arch:AVX)
+if(${QX_CPU_COMPATIBILITY_MODE})
+
+    # Only assume x86-64, which has at least SSE3.
+    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
+        target_compile_options(qx PUBLIC -march=nocona)
+    elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+        target_compile_options(qx PUBLIC -march=nocona)
+    elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
+        target_compile_options(qx PUBLIC /arch:SSE3)
+    else()
+        message(SEND_ERROR "Unsupported compiler: ${CMAKE_CXX_COMPILER_ID}")
+    endif()
+
 else()
-    message(SEND_ERROR "Unsupported compiler: ${CMAKE_CXX_COMPILER_ID}")
+
+    # Use newer instruction set extensions when supported.
+    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
+        target_compile_options(qx PUBLIC -march=native -mtune=native)
+    elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel")
+        target_compile_options(qx PUBLIC -ipo -xHost -no-prec-div)
+    elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+        target_compile_options(qx PUBLIC -march=native -mtune=native)
+    elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
+        # NOTE: this is making assumptions about what the host can do...
+        target_compile_options(qx PUBLIC /arch:AVX)
+    else()
+        message(SEND_ERROR "Unsupported compiler: ${CMAKE_CXX_COMPILER_ID}")
+    endif()
+
 endif()
 
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Alternatively, you can build and install from source using
 
     python3 -m pip install -v -e .
 
+The latter might run faster on your machine, as it allows the compiler to
+optimize for your particular CPU. The PyPI binaries assume that only SSE3 is
+available.
+
 ## Licensing
 
 QX is licensed under the Apache License, Version 2.0. See

--- a/include/qx/version.h
+++ b/include/qx/version.h
@@ -1,4 +1,4 @@
 #ifndef QX_VERSION
-#define QX_VERSION "0.4.1"
+#define QX_VERSION "0.4.2"
 #define QX_RELEASE_YEAR "2021"
 #endif

--- a/setup.py
+++ b/setup.py
@@ -169,6 +169,10 @@ class build_ext(_build_ext):
             if 'QX_BUILD_TESTS' in os.environ:
                 cmd = cmd['-DQX_BUILD_TESTS=ON']
 
+            # Enable CPU extension compatibility mode when requested.
+            if 'QX_CPU_COMPATIBILITY_MODE' in os.environ:
+                cmd = cmd['-DQX_CPU_COMPATIBILITY_MODE=ON']
+
             # Run cmake configuration.
             cmd & FG
 


### PR DESCRIPTION
At least the Linux wheels generated by CI don't work on my pretty recent machine, so I imagine it wouldn't work on many other PCs either. In general it makes no sense to optimize PyPI wheels for the GitHub runner that happens to be building them.