### PR TITLE
Add support for barriers

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -146,7 +146,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         choco install winflexbison3 --version 2.5.18.20190508
-        choco install swig --version 4.0.1
     - name: Enable CPU compatibility mode
       run: echo "QX_CPU_COMPATIBILITY_MODE=ON" >> $GITHUB_ENV
     - name: Build wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,6 @@ jobs:
       shell: powershell
       run: |
         choco install winflexbison3 --version 2.5.18.20190508
-        choco install swig --version 4.0.1
     - name: Select build type
       if: matrix.os == 'windows-latest'
       shell: powershell

--- a/include/qx/libqasm_interface.h
+++ b/include/qx/libqasm_interface.h
@@ -460,6 +460,13 @@ qx::circuit * load_cqasm_code(uint64_t qubits_count, compiler::SubCircuit &subci
        qx::gate * g;
        try
        {
+          if (
+             (*p_operation)->getType() == "barrier" ||
+             (*p_operation)->getType() == "skip" ||
+             (*p_operation)->getType() == "wait"
+          ) {
+             continue;
+          }
           g = gateLookup(**p_operation);
        }
        catch (const char * error)


### PR DESCRIPTION
Basically, just ignore barriers when they appear. Same for wait and skip instructions, which gave an internal error before.